### PR TITLE
Change to APIv2 in case digest authentication not needed

### DIFF
--- a/goslideapi/goslideapi.py
+++ b/goslideapi/goslideapi.py
@@ -597,9 +597,15 @@ class GoSlideLocal:
         if apiversion == 1:
 
             # do request to obtain a WWW-authentication header:
-            respstatus, resptext = await self._dorequest(reqtype, url)
+            respstatus, resptext = await self._dorequest(reqtype, url, data=data)
+            
+            # Authentication was not needed. Slide has been upgraded.
+            if respstatus == 200:
+                _LOGGER.debug("Slide %s updated to API version 2", hostname)
+                self._slide_api[hostname] = 2
+                return resptext
 
-            # Only a 401 response is correct
+            # Otherwise, we should have a 401 response
             if respstatus == 401:
 
                 # The resptext contains the WWW-Authentication header


### PR DESCRIPTION
Some slides have been updated to the v2 API, meaning Digest authentication is not required.

Current behavior is that an error is thrown when a v2 slide is called with the v1 API.

Proposal is to automatically switch to the v2 API in case the request is successfully handled without authentication header in the request.