### PR TITLE
Add session to local API

### DIFF
--- a/goslideapi/goslideapi.py
+++ b/goslideapi/goslideapi.py
@@ -452,7 +452,7 @@ class GoSlideLocal:
             x = x.encode("utf-8")
         return hashlib.md5(x).hexdigest()
 
-    def _make_digest_auth(self, username, password, method, uri, my_auth):
+    def _make_digest_auth(self, username, password, uri, my_auth):
         nonce = re.findall(r'nonce="(.*?)"', my_auth)[0]
         realm = re.findall(r'realm="(.*?)"', my_auth)[0]
         qop = re.findall(r'qop="(.*?)"', my_auth)[0]
@@ -471,7 +471,7 @@ class GoSlideLocal:
         HA1 = self._md5_utf8(username + ":" + realm + ":" + password)
 
         # calculate HA2
-        HA2 = self._md5_utf8(method + ":" + uri)
+        HA2 = self._md5_utf8("POST:" + uri)
 
         if qop == "auth" or "auth" in qop.split(","):
             # calculate client response


### PR DESCRIPTION
Adding the possibility to pass on an existing websession to the client. This enables to improve efficiency in environments with many devices and services connected via HTTP and is a requirement for the platinum rating in the HA quality scale (https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/inject-websession).

As in the local API there is currently no GET-request, I also deleted the reqtype, so that only session.post can be called (L518).

Finally, I added an empty string as default value for password in the initialization, so that for API 2 (which already is the default) no fake password needs to be given.

I have tested the changes in my test environment with API 2 (also with shared websession). Would be good, though, if you could test it in your environment as well.